### PR TITLE
Cleanup rocksdb engine

### DIFF
--- a/src/main/scala/com/cesarla/persistence/RocksDBEngine.scala
+++ b/src/main/scala/com/cesarla/persistence/RocksDBEngine.scala
@@ -3,20 +3,20 @@ package com.cesarla.persistence
 import java.time.Instant
 import java.util.concurrent.locks.Lock
 
-import akka.actor.ActorSystem
-import akka.event.Logging
-import com.cesarla.http.KeyValueRoutes
 import com.cesarla.models.{Column, Key}
 import com.google.common.util.concurrent.Striped
 import org.rocksdb.{Options, RocksDB}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class RocksDBEngine(rocksDB: RocksDB)(implicit system: ActorSystem) extends KeyValueEngine {
+class RocksDBEngine(rocksDB: RocksDB) extends KeyValueEngine {
 
-  lazy val log = Logging(system, classOf[KeyValueRoutes])
-
-  val lazyWeakSemaphore: Striped[Lock] = Striped.lazyWeakLock(10)
+  /**
+    * RocksDB doesn't expose the MergeOperator in the Java API, so until then,
+    * rCache uses locks at key level to perform a Read-Modify-Write in an
+    * atomic fashion.
+    */
+  private[this] val lazyWeakLock: Striped[Lock] = Striped.lazyWeakLock(256)
 
   override def get[A](key: Key[A], timestamp: Instant)(implicit keyEncoder: KeyEncoder[A],
                                                        valueDecoder: ColumnDecoder[A],
@@ -29,41 +29,41 @@ class RocksDBEngine(rocksDB: RocksDB)(implicit system: ActorSystem) extends KeyV
                                                       valueFormat: ColumnCodec[A],
                                                       ec: ExecutionContext): Future[Unit] = Future {
     val encodedKey = keyEncoder.encode(key)
-    val lock: Lock = lazyWeakSemaphore.get(key)
-    lock.lock()
-    try {
+    lockByKey(key) {
       Option(rocksDB.get(encodedKey)).flatMap(r => valueFormat.decode(r)) match {
         case Some(Column(_, _, prevTimestamp, _)) if prevTimestamp.getNano > column.timestamp.getNano => ()
         case _ =>
           val encodedColumn = valueFormat.encode(column)
           rocksDB.put(encodedKey, encodedColumn)
       }
-    } finally {
-      lock.unlock()
     }
-    ()
   }
 
   override def delete[A](key: Key[A], timestamp: Instant)(implicit keyEncoder: KeyEncoder[A],
                                                           valueReader: ColumnCodec[A],
                                                           ec: ExecutionContext): Future[Unit] = Future {
     val encodedKey = keyEncoder.encode(key)
-    val lock: Lock = lazyWeakSemaphore.get(key)
-    lock.lock()
-    try {
+    lockByKey(key) {
       Option(rocksDB.get(encodedKey)).flatMap(r => valueReader.decode(r)) match {
         case Some(Column(_, _, prevTimestamp, _)) if prevTimestamp.getNano > timestamp.getNano => ()
         case _                                                                                 => rocksDB.delete(encodedKey)
       }
+    }
+  }
+
+  private[this] def lockByKey[A, B](key: Key[A])(block: => B): B = {
+    val lock: Lock = lazyWeakLock.get(key)
+    lock.lock()
+    try {
+      block
     } finally {
       lock.unlock()
     }
-    ()
   }
 }
 
 object RocksDBEngine {
-  def load(path: String)(implicit system: ActorSystem): RocksDBEngine = {
+  def load(path: String): RocksDBEngine = {
     RocksDB.loadLibrary()
     val options = new Options().setCreateIfMissing(true)
     new RocksDBEngine(RocksDB.open(options, path))

--- a/src/test/scala/com/cesarla/persistence/RocksDBEngineSpec.scala
+++ b/src/test/scala/com/cesarla/persistence/RocksDBEngineSpec.scala
@@ -18,6 +18,7 @@ class RocksDBEngineSpec extends WordSpec with Matchers with MockFactory with Fix
     "get a column" should {
       "get an existing key" in new Scope {
         (mockRocksDB.get(_: Array[Byte])).expects(*).returning(byteArrayFixture).once()
+        (mockRocksDB.delete(_: Array[Byte])).expects(*).returning(()).never()
 
         implicit val dummyDecodeFunction: Decoder[Column[String]] =
           Decoder[Column[String]]((_: Array[Byte]) => Some(columnFixture("value")))
@@ -26,8 +27,20 @@ class RocksDBEngineSpec extends WordSpec with Matchers with MockFactory with Fix
 
         result should ===(Some(columnFixture("value")))
       }
+      "delete expired value" in new Scope {
+        (mockRocksDB.get(_: Array[Byte])).expects(*).returning(byteArrayFixture).once()
+        (mockRocksDB.delete(_: Array[Byte])).expects(*).returning(()).once()
+
+        implicit val dummyDecodeFunction: Decoder[Column[String]] =
+          Decoder[Column[String]]((_: Array[Byte]) => Some(columnFixtureWithTtl("value")))
+        val result: Option[Column[String]] =
+          Await.result(rocksDBEngine.get[String](keyFixture, Instant.now()), 2.seconds)
+
+        result should ===(None)
+      }
       "handle key not found" in new Scope {
         (mockRocksDB.get(_: Array[Byte])).expects(*).returning(null).once()
+        (mockRocksDB.delete(_: Array[Byte])).expects(*).returning(()).never()
 
         val result: Option[Column[String]] =
           Await.result(rocksDBEngine.get[String](keyFixture, instantFixture), 2.seconds)

--- a/src/test/scala/com/cesarla/persistence/RocksDBEngineSpec.scala
+++ b/src/test/scala/com/cesarla/persistence/RocksDBEngineSpec.scala
@@ -89,7 +89,7 @@ class RocksDBEngineSpec extends WordSpec with Matchers with MockFactory with Fix
           (mockRocksDB.delete(_: Array[Byte])).expects(*).returning(()).once()
           implicit val dummyDecodeFunction: Decoder[Column[String]] =
             Decoder[Column[String]]((_: Array[Byte]) => Some(columnFixture("value")))
-          Await.result(rocksDBEngine.delete[String](keyFixture, instantFixture), 2.seconds) should ===(())
+          Await.result(rocksDBEngine.delete[String](keyFixture, Instant.now()), 2.seconds) should ===(())
         }
       }
 


### PR DESCRIPTION
 - Refactors RocksDBEngine in order to simplify locks usage
 - Adds abstractions in RocksDBEngine in order to avoid code duplication
 - Avoids reading (and deletes) expired columns